### PR TITLE
docs: add JSDoc to `divider` component

### DIFF
--- a/src/divider/divider.stories.ts
+++ b/src/divider/divider.stories.ts
@@ -1,9 +1,9 @@
-import { html, TemplateResult } from "lit";
-import "./index.js";
+import { html, TemplateResult } from 'lit';
+import './index.js';
 
 export default {
-  title: "Divider",
-  component: "tap-divider",
+  title: 'Divider',
+  component: 'tap-divider',
   argTypes: {},
 };
 

--- a/src/divider/divider.style.ts
+++ b/src/divider/divider.style.ts
@@ -1,4 +1,4 @@
-import { css } from "lit";
+import { css } from 'lit';
 
 export default css`
   :host {
@@ -22,15 +22,15 @@ export default css`
     margin: var(--tap-sys-spacing-4) 0;
   }
 
-  :host([type="thin"]) {
+  :host([type='thin']) {
     height: var(--tap-sys-spacing-1);
   }
 
-  :host([type="medium"]) {
+  :host([type='medium']) {
     height: var(--tap-sys-spacing-2);
   }
 
-  :host([type="bold"]) {
+  :host([type='bold']) {
     background-color: var(--tap-sys-color-surface-secondary);
     height: var(--tap-sys-spacing-4);
   }

--- a/src/divider/divider.style.ts
+++ b/src/divider/divider.style.ts
@@ -17,21 +17,27 @@ export default css`
 
   :host {
     display: block;
-    background-color: var(--tap-sys-color-border-primary);
+    background-color: var(
+      --tap-divider-background-color,
+      var(--tap-sys-color-border-primary)
+    );
     width: 100%;
-    margin: var(--tap-sys-spacing-4) 0;
+    margin: var(--tap-devider-margin, var(--tap-sys-spacing-4)) 0;
   }
 
   :host([type='thin']) {
-    height: var(--tap-sys-spacing-1);
+    height: var(--tap-divider-thin-height, var(--tap-sys-spacing-1));
   }
 
   :host([type='medium']) {
-    height: var(--tap-sys-spacing-2);
+    height: var(--tap-divider-medium-height, var(--tap-sys-spacing-2));
   }
 
   :host([type='bold']) {
-    background-color: var(--tap-sys-color-surface-secondary);
-    height: var(--tap-sys-spacing-4);
+    background-color: var(
+      --tap-divider-bold-background-color,
+      var(--tap-sys-color-surface-secondary)
+    );
+    height: var(--tap-divider-bold-height, var(--tap-sys-spacing-4));
   }
 `;

--- a/src/divider/divider.style.ts
+++ b/src/divider/divider.style.ts
@@ -22,7 +22,7 @@ export default css`
       var(--tap-sys-color-border-primary)
     );
     width: 100%;
-    margin: var(--tap-devider-margin, var(--tap-sys-spacing-4)) 0;
+    margin: var(--tap-divider-margin, var(--tap-sys-spacing-4)) 0;
   }
 
   :host([type='thin']) {

--- a/src/divider/divider.ts
+++ b/src/divider/divider.ts
@@ -1,11 +1,11 @@
-import { LitElement } from "lit";
-import { property } from "lit/decorators.js";
+import { LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 
 export class Divider extends LitElement {
-  @property({ reflect: true }) type: "thin" | "medium" | "bold" = "medium";
+  @property({ reflect: true }) type: 'thin' | 'medium' | 'bold' = 'medium';
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute("role", "separator");
+    this.setAttribute('role', 'separator');
   }
 }

--- a/src/divider/index.ts
+++ b/src/divider/index.ts
@@ -1,14 +1,14 @@
-import { customElement } from "lit/decorators.js";
-import { Divider } from "./divider.js";
-import styles from "./divider.style.js";
+import { customElement } from 'lit/decorators.js';
+import { Divider } from './divider.js';
+import styles from './divider.style.js';
 
-@customElement("tap-divider")
+@customElement('tap-divider')
 export class TapDivider extends Divider {
   static readonly styles = [styles];
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    "tap-divider": TapDivider;
+    'tap-divider': TapDivider;
   }
 }

--- a/src/divider/index.ts
+++ b/src/divider/index.ts
@@ -2,6 +2,37 @@ import { customElement } from 'lit/decorators.js';
 import { Divider } from './divider.js';
 import styles from './divider.style.js';
 
+/**
+ * ### Example
+ *
+ *
+ * ##### Simple
+ *
+ * ```html
+ * <tap-divider></tap-divider>
+ * ```
+ *
+ * ##### Different Types
+ *
+ * ```html
+ * <tap-divider type="thin"></tap-divider>
+ * <tap-divider type="medium"></tap-divider>
+ * <tap-divider type="bold"></tap-divider>
+ * ```
+ *
+ * @summary A divider component used to separate content.
+ *
+ * @prop {`'thin'` \| `'medium'` \| `'bold'`} [`type`=`'medium'`] - The thickness of the divider.
+ *
+ * @csspart [`divider`] - The main container for the divider.
+ *
+ * @cssprop [`--tap-divider-background-color`=`--tap-sys-color-border-primary`] - The background color of the divider.
+ * @cssprop [`--tap-divider-margin`=`--tap-sys-spacing-4`] - The margin around the divider.
+ * @cssprop [`--tap-divider-thin-height`=`--tap-sys-spacing-1`] - The height of the thin divider.
+ * @cssprop [`--tap-divider-medium-height`=`--tap-sys-spacing-2`] - The height of the medium divider.
+ * @cssprop [`--tap-divider-bold-background-color`=`--tap-sys-color-surface-secondary`] - The background color of the bold divider.
+ * @cssprop [`--tap-divider-bold-height`=`--tap-sys-spacing-4`] - The height of the bold divider.
+ */
 @customElement('tap-divider')
 export class TapDivider extends Divider {
   static readonly styles = [styles];


### PR DESCRIPTION
This PR fixed https://github.com/Tap30/web-components/issues/94:

- [x] `divider`