### PR TITLE
docs: add JSDoc to `segmented-button` and `segmented-button-group` components

### DIFF
--- a/src/segmented-button-group/index.ts
+++ b/src/segmented-button-group/index.ts
@@ -1,14 +1,14 @@
-import { customElement } from "lit/decorators.js";
-import { SegmentedButtonGroup } from "./segmented-button-group";
-import styles from "./segmented-button-group.style";
+import { customElement } from 'lit/decorators.js';
+import { SegmentedButtonGroup } from './segmented-button-group';
+import styles from './segmented-button-group.style';
 
-@customElement("tap-segmented-button-group")
+@customElement('tap-segmented-button-group')
 export class TapSegmentedButtonGroup extends SegmentedButtonGroup {
   static readonly styles = [styles];
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    "tap-segmented-button-group": TapSegmentedButtonGroup;
+    'tap-segmented-button-group': TapSegmentedButtonGroup;
   }
 }

--- a/src/segmented-button-group/index.ts
+++ b/src/segmented-button-group/index.ts
@@ -2,6 +2,46 @@ import { customElement } from 'lit/decorators.js';
 import { SegmentedButtonGroup } from './segmented-button-group';
 import styles from './segmented-button-group.style';
 
+/**
+ * ### Example
+ *
+ *
+ * ##### Simple
+ *
+ * ```html
+ * <tap-segmented-button-group>
+ *   <tap-segmented-button>Button 1</tap-segmented-button>
+ *   <tap-segmented-button>Button 2</tap-segmented-button>
+ *   <tap-segmented-button>Button 3</tap-segmented-button>
+ * </tap-segmented-button-group>
+ * ```
+ *
+ * ##### With Sizes
+ *
+ * ```html
+ * <tap-segmented-button-group size="sm">
+ *   <tap-segmented-button>Small Button 1</tap-segmented-button>
+ *   <tap-segmented-button>Small Button 2</tap-segmented-button>
+ * </tap-segmented-button-group>
+ *
+ * <tap-segmented-button-group size="md">
+ *   <tap-segmented-button>Medium Button 1</tap-segmented-button>
+ *   <tap-segmented-button>Medium Button 2</tap-segmented-button>
+ * </tap-segmented-button-group>
+ * ```
+ *
+ * @summary A group of segmented buttons.
+ *
+ * @prop {`'sm'` \| `'md'`} [`size`=`'md'`] - The size of the segmented button group.
+ *
+ * @csspart [`button-group`] - The main container for the button group.
+ *
+ * @cssprop [`--tap-segmented-button-group-color-surface`=`--tap-sys-color-surface-secondary`] - The background color of the button group.
+ * @cssprop [`--tap-segmented-button-group-border-radius`=`--tap-sys-radius-full`] - The border radius of the button group.
+ * @cssprop [`--tap-segmented-button-group-padding`=`--tap-sys-spacing-3`] - The padding inside the button group.
+ * @cssprop [`--tap-segmented-button-group-sm-height`=`--tap-sys-spacing-10`] - The height of the small size button group.
+ * @cssprop [`--tap-segmented-button-group-md-height`=`--tap-sys-spacing-11`] - The height of the medium size button group.
+ */
 @customElement('tap-segmented-button-group')
 export class TapSegmentedButtonGroup extends SegmentedButtonGroup {
   static readonly styles = [styles];

--- a/src/segmented-button-group/segmented-button-group.stories.ts
+++ b/src/segmented-button-group/segmented-button-group.stories.ts
@@ -1,10 +1,10 @@
-import { html, TemplateResult } from "lit";
-import "../segmented-button";
-import "./index.js";
+import { html, TemplateResult } from 'lit';
+import '../segmented-button';
+import './index.js';
 
 export default {
-  title: "Segmented Button Group",
-  component: "tap-segmented-button-group",
+  title: 'Segmented Button Group',
+  component: 'tap-segmented-button-group',
   argTypes: {},
 };
 

--- a/src/segmented-button-group/segmented-button-group.ts
+++ b/src/segmented-button-group/segmented-button-group.ts
@@ -1,17 +1,17 @@
-import { LitElement, html, nothing } from "lit";
-import { property, queryAssignedElements } from "lit/decorators.js";
-import { SegmentedButton } from "../segmented-button/segmented-button.js";
+import { LitElement, html, nothing } from 'lit';
+import { property, queryAssignedElements } from 'lit/decorators.js';
+import { SegmentedButton } from '../segmented-button/segmented-button.js';
 
 export class SegmentedButtonGroup extends LitElement {
-  @property({ reflect: true }) size: "sm" | "md" = "md";
+  @property({ reflect: true }) size: 'sm' | 'md' = 'md';
 
   @queryAssignedElements() private buttons!: SegmentedButton[];
 
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener(
-      "segmented-button-click",
-      this.handleSegmentedButtonClick
+      'segmented-button-click',
+      this.handleSegmentedButtonClick,
     );
   }
 
@@ -42,14 +42,14 @@ export class SegmentedButtonGroup extends LitElement {
     });
 
     this.dispatchEvent(
-      new CustomEvent("segmented-button-group-change", {
+      new CustomEvent('segmented-button-group-change', {
         detail: {
           selected: clicked,
           index,
         },
         bubbles: true,
         composed: true,
-      })
+      }),
     );
   }
 

--- a/src/segmented-button/index.ts
+++ b/src/segmented-button/index.ts
@@ -1,14 +1,14 @@
-import { customElement } from "lit/decorators.js";
-import { SegmentedButton } from "./segmented-button";
-import styles from "./segmented-button.style";
+import { customElement } from 'lit/decorators.js';
+import { SegmentedButton } from './segmented-button';
+import styles from './segmented-button.style';
 
-@customElement("tap-segmented-button")
+@customElement('tap-segmented-button')
 export class TapSegmentedButton extends SegmentedButton {
   static readonly styles = [styles];
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    "tap-segmented-button": TapSegmentedButton;
+    'tap-segmented-button': TapSegmentedButton;
   }
 }

--- a/src/segmented-button/index.ts
+++ b/src/segmented-button/index.ts
@@ -2,6 +2,43 @@ import { customElement } from 'lit/decorators.js';
 import { SegmentedButton } from './segmented-button';
 import styles from './segmented-button.style';
 
+/**
+ * ### Example
+ *
+ *
+ * ##### Simple
+ *
+ * ```html
+ * <tap-segmented-button>Button</tap-segmented-button>
+ * ```
+ *
+ * ##### Selected
+ *
+ * ```html
+ * <tap-segmented-button selected>Selected Button</tap-segmented-button>
+ * ```
+ *
+ * ##### Disabled
+ *
+ * ```html
+ * <tap-segmented-button disabled>Disabled Button</tap-segmented-button>
+ * ```
+ *
+ * @summary A segmented button component.
+ *
+ * @prop {`boolean`} [`selected`=`false`] - Indicates whether the button is selected.
+ * @prop {`boolean`} [`disabled`=`false`] - Indicates whether the button is disabled.
+ *
+ * @csspart [`button`] - The main container for the button.
+ *
+ * @cssprop [`--tap-font-family`=`--tap-sys-font-family`] - The font family used in the button.
+ * @cssprop [`--tap-segmented-button-border-radius`=`--tap-sys-radius-full`] - The border radius of the button.
+ * @cssprop [`--tap-segmented-button-color`=`--tap-sys-color-content-primary`] - The text color of the button.
+ * @cssprop [`--tap-segmented-button-line-height`=`--tap-sys-typography-label-sm-height`] - The line height of the button text.
+ * @cssprop [`--tap-segmented-button-font-size`=`--tap-sys-typography-label-sm-size`] - The font size of the button text.
+ * @cssprop [`--tap-segmented-button-font-weight`=`--tap-sys-typography-label-sm-weight`] - The font weight of the button text.
+ * @cssprop [`--tap-segmented-button-selected-background-color`=`--tap-sys-color-surface-primary`] - The background color of the selected button.
+ */
 @customElement('tap-segmented-button')
 export class TapSegmentedButton extends SegmentedButton {
   static readonly styles = [styles];

--- a/src/segmented-button/segmented-button.style.ts
+++ b/src/segmented-button/segmented-button.style.ts
@@ -1,4 +1,4 @@
-import { css } from "lit";
+import { css } from 'lit';
 
 export default css`
   :host {

--- a/src/segmented-button/segmented-button.style.ts
+++ b/src/segmented-button/segmented-button.style.ts
@@ -38,16 +38,34 @@ export default css`
     text-decoration: none;
     font: inherit;
     gap: inherit;
-    font-family: var(--tap-sys-font-family);
-    border-radius: var(--tap-sys-radius-full);
-    color: var(--tap-sys-color-content-primary);
-    line-height: var(--tap-sys-typography-label-sm-height);
-    font-size: var(--tap-sys-typography-label-sm-size);
-    font-weight: var(--tap-sys-typography-label-sm-weight);
+    font-family: var(--tap-font-family, var(--tap-sys-font-family));
+    border-radius: var(
+      --tap-segmented-button-border-radius,
+      var(--tap-sys-radius-full)
+    );
+    color: var(
+      --tap-segmented-button-color,
+      var(--tap-sys-color-content-primary)
+    );
+    line-height: var(
+      --tap-segmented-button-line-height,
+      var(--tap-sys-typography-label-sm-height)
+    );
+    font-size: var(
+      --tap-segmented-button-font-size,
+      var(--tap-sys-typography-label-sm-size)
+    );
+    font-weight: var(
+      --tap-segmented-button-font-weight,
+      var(--tap-sys-typography-label-sm-weight)
+    );
   }
 
   :host([selected]) .button {
-    background-color: var(--tap-sys-color-surface-primary);
+    background-color: var(
+      --tap-segmented-button-selected-background-color,
+      var(--tap-sys-color-surface-primary)
+    );
     /* FIXME: we dont have shadow tokens yet  */
     box-shadow: 0px 4px 16px 0px #0000001a;
   }

--- a/src/segmented-button/segmented-button.ts
+++ b/src/segmented-button/segmented-button.ts
@@ -1,5 +1,5 @@
-import { LitElement, html, nothing } from "lit";
-import { property } from "lit/decorators.js";
+import { LitElement, html, nothing } from 'lit';
+import { property } from 'lit/decorators.js';
 
 export class SegmentedButton extends LitElement {
   @property({ type: Boolean, reflect: true }) selected = false;
@@ -7,10 +7,10 @@ export class SegmentedButton extends LitElement {
 
   private handleClick() {
     this.dispatchEvent(
-      new Event("segmented-button-click", {
+      new Event('segmented-button-click', {
         bubbles: true,
         composed: true,
-      })
+      }),
     );
   }
 
@@ -21,7 +21,7 @@ export class SegmentedButton extends LitElement {
         part="button"
         aria-label=${nothing}
         aria-pressed=${this.selected}
-        tabindex="${this.disabled ? "-1" : "0"}"
+        tabindex="${this.disabled ? '-1' : '0'}"
         ?disabled=${this.disabled}
         @click="${this.handleClick}"
       >


### PR DESCRIPTION
This PR fixed https://github.com/Tap30/web-components/issues/94:

- [x] `segmented-button`
- [x] `segmented-button-group`