### PR TITLE
feat(inputs): add `size` property for text inputs

### DIFF
--- a/packages/web-components/src/base-input/base-input.ts
+++ b/packages/web-components/src/base-input/base-input.ts
@@ -68,6 +68,12 @@ export abstract class BaseInput extends BaseClass {
   @property({ type: String })
   public override inputMode = "";
 
+  /**
+   * The size of the input.
+   */
+  @property()
+  public size: "sm" | "md" = "md";
+
   constructor() {
     super();
 
@@ -151,6 +157,7 @@ export abstract class BaseInput extends BaseClass {
     const rootClasses = classMap({
       root: true,
       disabled: this.disabled,
+      [this.size]: true,
     });
 
     return html`

--- a/packages/web-components/src/base-input/base-input.ts
+++ b/packages/web-components/src/base-input/base-input.ts
@@ -5,7 +5,7 @@ import {
   type TemplateResult,
 } from "lit";
 import { property } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
+import { type ClassInfo, classMap } from "lit/directives/class-map.js";
 import { KeyboardKeys } from "../internals";
 import {
   dispatchActivationClick,
@@ -67,12 +67,6 @@ export abstract class BaseInput extends BaseClass {
 
   @property({ type: String })
   public override inputMode = "";
-
-  /**
-   * The size of the input.
-   */
-  @property()
-  public size: "sm" | "md" = "md";
 
   constructor() {
     super();
@@ -153,12 +147,15 @@ export abstract class BaseInput extends BaseClass {
     }
   }
 
-  protected override render() {
-    const rootClasses = classMap({
+  protected getRootClasses(): ClassInfo {
+    return {
       root: true,
       disabled: this.disabled,
-      [this.size]: true,
-    });
+    };
+  }
+
+  protected override render() {
+    const rootClasses = classMap(this.getRootClasses());
 
     return html`
       <div

--- a/packages/web-components/src/base-text-input/base-text-input.style.ts
+++ b/packages/web-components/src/base-text-input/base-text-input.style.ts
@@ -36,7 +36,7 @@ export default css`
 
     --input-support-text-size: var(--tapsi-typography-body-sm-size);
     --input-label-text-size: var(--tapsi-typography-label-md-size);
-    --input-control-size: var(--tapsi-typography-body-md-size);
+    --input-control-text-size: var(--tapsi-typography-body-md-size);
 
     --input-support-text-height: var(--tapsi-typography-body-sm-height);
     --input-label-text-height: var(--tapsi-typography-label-md-height);
@@ -44,7 +44,7 @@ export default css`
 
     --input-support-text-weight: var(--tapsi-typography-body-sm-weight);
     --input-label-text-weight: var(--tapsi-typography-label-md-weight);
-    --input-control-weight: var(--tapsi-typography-body-md-weight);
+    --input-control-text-weight: var(--tapsi-typography-body-md-weight);
 
     --input-padding-horizontal: var(--tapsi-spacing-6);
 
@@ -67,7 +67,7 @@ export default css`
   .root.sm {
     --input-support-text-size: var(--tapsi-typography-body-xs-size);
     --input-label-text-size: var(--tapsi-typography-label-sm-size);
-    --input-control-size: var(--tapsi-typography-body-sm-size);
+    --input-control-text-size: var(--tapsi-typography-body-sm-size);
 
     --input-support-text-height: var(--tapsi-typography-body-xs-height);
     --input-label-text-height: var(--tapsi-typography-label-sm-height);
@@ -75,7 +75,7 @@ export default css`
 
     --input-support-text-weight: var(--tapsi-typography-body-xs-weight);
     --input-label-text-weight: var(--tapsi-typography-label-sm-weight);
-    --input-control-weight: var(--tapsi-typography-body-sm-weight);
+    --input-control-text-weight: var(--tapsi-typography-body-sm-weight);
 
     --input-padding-horizontal: var(--tapsi-spacing-5);
 
@@ -85,7 +85,7 @@ export default css`
   .root.md {
     --input-support-text-size: var(--tapsi-typography-body-sm-size);
     --input-label-text-size: var(--tapsi-typography-label-md-size);
-    --input-control-size: var(--tapsi-typography-body-md-size);
+    --input-control-text-size: var(--tapsi-typography-body-md-size);
 
     --input-support-text-height: var(--tapsi-typography-body-sm-height);
     --input-label-text-height: var(--tapsi-typography-label-md-height);
@@ -93,7 +93,7 @@ export default css`
 
     --input-support-text-weight: var(--tapsi-typography-body-sm-weight);
     --input-label-text-weight: var(--tapsi-typography-label-md-weight);
-    --input-control-weight: var(--tapsi-typography-body-md-weight);
+    --input-control-text-weight: var(--tapsi-typography-body-md-weight);
 
     --input-padding-horizontal: var(--tapsi-spacing-6);
 
@@ -145,8 +145,8 @@ export default css`
 
     font-family: var(--tapsi-font-family);
     line-height: var(--input-control-text-height);
-    font-size: var(--input-control-size);
-    font-weight: var(--input-control-weight);
+    font-size: var(--input-control-text-size);
+    font-weight: var(--input-control-text-weight);
   }
 
   .input::placeholder {
@@ -154,8 +154,8 @@ export default css`
 
     font-family: var(--tapsi-font-family);
     line-height: var(--input-control-text-height);
-    font-size: var(--input-control-size);
-    font-weight: var(--input-control-weight);
+    font-size: var(--input-control-text-size);
+    font-weight: var(--input-control-text-weight);
   }
 
   .leading-icon {

--- a/packages/web-components/src/base-text-input/base-text-input.style.ts
+++ b/packages/web-components/src/base-text-input/base-text-input.style.ts
@@ -34,6 +34,22 @@ export default css`
     --input-icon-color: var(--tapsi-color-content-secondary);
     --input-placeholder-color: var(--tapsi-color-content-tertiary);
 
+    --input-support-text-size: var(--tapsi-typography-body-sm-size);
+    --input-label-text-size: var(--tapsi-typography-label-md-size);
+    --input-control-size: var(--tapsi-typography-body-md-size);
+
+    --input-support-text-height: var(--tapsi-typography-body-sm-height);
+    --input-label-text-height: var(--tapsi-typography-label-md-height);
+    --input-control-text-height: var(--tapsi-typography-body-md-height);
+
+    --input-support-text-weight: var(--tapsi-typography-body-sm-weight);
+    --input-label-text-weight: var(--tapsi-typography-label-md-weight);
+    --input-control-weight: var(--tapsi-typography-body-md-weight);
+
+    --input-padding-horizontal: var(--tapsi-spacing-6);
+
+    --input-control-height: 3.25rem;
+
     display: inline-block;
     vertical-align: middle;
   }
@@ -46,6 +62,42 @@ export default css`
     --input-color: var(--tapsi-color-content-disabled);
     --input-icon-color: var(--tapsi-color-content-disabled);
     --input-placeholder-color: var(--tapsi-color-content-disabled);
+  }
+
+  .root.sm {
+    --input-support-text-size: var(--tapsi-typography-body-xs-size);
+    --input-label-text-size: var(--tapsi-typography-label-sm-size);
+    --input-control-size: var(--tapsi-typography-body-sm-size);
+
+    --input-support-text-height: var(--tapsi-typography-body-xs-height);
+    --input-label-text-height: var(--tapsi-typography-label-sm-height);
+    --input-control-text-height: var(--tapsi-typography-body-sm-height);
+
+    --input-support-text-weight: var(--tapsi-typography-body-xs-weight);
+    --input-label-text-weight: var(--tapsi-typography-label-sm-weight);
+    --input-control-weight: var(--tapsi-typography-body-sm-weight);
+
+    --input-padding-horizontal: var(--tapsi-spacing-5);
+
+    --input-control-height: 2.5rem;
+  }
+
+  .root.md {
+    --input-support-text-size: var(--tapsi-typography-body-sm-size);
+    --input-label-text-size: var(--tapsi-typography-label-md-size);
+    --input-control-size: var(--tapsi-typography-body-md-size);
+
+    --input-support-text-height: var(--tapsi-typography-body-sm-height);
+    --input-label-text-height: var(--tapsi-typography-label-md-height);
+    --input-control-text-height: var(--tapsi-typography-body-md-height);
+
+    --input-support-text-weight: var(--tapsi-typography-body-sm-weight);
+    --input-label-text-weight: var(--tapsi-typography-label-md-weight);
+    --input-control-weight: var(--tapsi-typography-body-md-weight);
+
+    --input-padding-horizontal: var(--tapsi-spacing-6);
+
+    --input-control-height: 3.25rem;
   }
 
   .control.error {
@@ -68,11 +120,11 @@ export default css`
     display: flex;
     align-items: center;
 
-    height: 3.25rem;
+    height: var(--input-control-height);
     width: 100%;
 
-    padding-right: var(--tapsi-spacing-6);
-    padding-left: var(--tapsi-spacing-6);
+    padding-right: var(--input-padding-horizontal);
+    padding-left: var(--input-padding-horizontal);
     gap: var(--tapsi-spacing-4);
     border-radius: var(--tapsi-radius-3);
 
@@ -92,18 +144,18 @@ export default css`
     caret-color: var(--tapsi-color-surface-accent);
 
     font-family: var(--tapsi-font-family);
-    line-height: var(--tapsi-typography-body-md-height);
-    font-size: var(--tapsi-typography-body-md-size);
-    font-weight: var(--tapsi-typography-body-md-weight);
+    line-height: var(--input-control-text-height);
+    font-size: var(--input-control-size);
+    font-weight: var(--input-control-weight);
   }
 
   .input::placeholder {
     color: var(--input-placeholder-color);
 
     font-family: var(--tapsi-font-family);
-    line-height: var(--tapsi-typography-body-md-height);
-    font-size: var(--tapsi-typography-body-md-size);
-    font-weight: var(--tapsi-typography-body-md-weight);
+    line-height: var(--input-control-text-height);
+    font-size: var(--input-control-size);
+    font-weight: var(--input-control-weight);
   }
 
   .leading-icon {
@@ -137,17 +189,17 @@ export default css`
     color: var(--input-support-color);
 
     font-family: var(--tapsi-font-family);
-    line-height: var(--tapsi-typography-body-sm-height);
-    font-size: var(--tapsi-typography-body-sm-size);
-    font-weight: var(--tapsi-typography-body-sm-weight);
+    line-height: var(--input-support-text-height);
+    font-size: var(--input-support-text-size);
+    font-weight: var(--input-support-text-weight);
   }
 
   .label {
     color: var(--input-label-color);
 
     font-family: var(--tapsi-font-family);
-    line-height: var(--tapsi-typography-label-md-height);
-    font-size: var(--tapsi-typography-label-md-size);
-    font-weight: var(--tapsi-typography-label-md-weight);
+    line-height: var(--input-label-text-height);
+    font-size: var(--input-label-text-size);
+    font-weight: var(--input-label-text-weight);
   }
 `;

--- a/packages/web-components/src/base-text-input/base-text-input.ts
+++ b/packages/web-components/src/base-text-input/base-text-input.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
+import { type ClassInfo, classMap } from "lit/directives/class-map.js";
 import BaseInput from "../base-input";
 import {
   getFormValue,
@@ -103,6 +103,12 @@ export abstract class BaseTextInput extends BaseInput {
    */
   @property({ type: Boolean, attribute: "hide-label" })
   public hideLabel = false;
+
+  /**
+   * The size of the input.
+   */
+  @property()
+  public size: "sm" | "md" = "md";
 
   @state()
   private _dirty = false;
@@ -306,6 +312,15 @@ export abstract class BaseTextInput extends BaseInput {
   }
 
   protected abstract renderInput(): TemplateResult;
+
+  protected override getRootClasses(): ClassInfo {
+    const parentRootClasses = super.getRootClasses();
+
+    return {
+      ...parentRootClasses,
+      [this.size]: true,
+    };
+  }
 
   protected override renderControl() {
     const controlClasses = classMap({

--- a/packages/web-components/src/text-area/index.ts
+++ b/packages/web-components/src/text-area/index.ts
@@ -71,6 +71,7 @@ export { BaseTextInputSlots as Slots };
  * Identifies the element (or elements) that labels the input.
  *
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
+ * @prop {"sm" | "md"} [size="md"] - The size of the input.
  * @prop {boolean} [hide-label=false] - Whether to hide the label or not.
  * @prop {number} [rows=2] -
  * The number of rows to display for the text input.

--- a/packages/web-components/src/text-field/index.ts
+++ b/packages/web-components/src/text-field/index.ts
@@ -70,6 +70,7 @@ export { BaseTextInputSlots as Slots };
  * Identifies the element (or elements) that labels the input.
  *
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
+ * @prop {"sm" | "md"} [size="md"] - The size of the input.
  * @prop {boolean} [hide-label=false] - Whether to hide the label or not.
  * @prop {string} [type="text"] -
  * The `<input>` type to use, defaults to "text". The type greatly changes how


### PR DESCRIPTION
closes: #322 

<img width="451" alt="image" src="https://github.com/user-attachments/assets/25a9018b-632e-4024-b014-d6a195b4b198" />
