### PR TITLE
feat(text-inputs): add rounded property

### DIFF
--- a/packages/web-components/src/base-text-input/base-text-input.style.ts
+++ b/packages/web-components/src/base-text-input/base-text-input.style.ts
@@ -27,7 +27,6 @@ export default css`
 
   :host {
     --input-control-bg-color: var(--tapsi-color-surface-tertiary);
-    --input-control-border-color: transparent;
     --input-support-color: var(--tapsi-color-content-tertiary);
     --input-label-color: var(--tapsi-color-content-primary);
     --input-color: var(--tapsi-color-content-primary);
@@ -49,6 +48,9 @@ export default css`
     --input-padding-horizontal: var(--tapsi-spacing-6);
 
     --input-control-height: 3.25rem;
+
+    --input-control-border-color: transparent;
+    --input-control-border-radius: var(--tapsi-radius-3);
 
     display: inline-block;
     vertical-align: middle;
@@ -105,6 +107,14 @@ export default css`
     --input-control-border-color: var(--tapsi-color-border-negative);
   }
 
+  .root.md .control.rounded {
+    --input-control-border-radius: var(--tapsi-spacing-8);
+  }
+
+  .root.sm .control.rounded {
+    --input-control-border-radius: var(--tapsi-spacing-7);
+  }
+
   .control.error + .supporting-text {
     --input-support-color: var(--tapsi-color-content-negative);
   }
@@ -126,7 +136,7 @@ export default css`
     padding-right: var(--input-padding-horizontal);
     padding-left: var(--input-padding-horizontal);
     gap: var(--tapsi-spacing-4);
-    border-radius: var(--tapsi-radius-3);
+    border-radius: var(--input-control-border-radius);
 
     background-color: var(--input-control-bg-color);
     border: var(--tapsi-stroke-2) solid var(--input-control-border-color);

--- a/packages/web-components/src/base-text-input/base-text-input.ts
+++ b/packages/web-components/src/base-text-input/base-text-input.ts
@@ -105,6 +105,12 @@ export abstract class BaseTextInput extends BaseInput {
   public hideLabel = false;
 
   /**
+   * Whether the input is rounded or not.
+   */
+  @property({ type: Boolean })
+  public rounded = false;
+
+  /**
    * The size of the input.
    */
   @property()
@@ -327,6 +333,7 @@ export abstract class BaseTextInput extends BaseInput {
       control: true,
       error: this.hasError(),
       readonly: this.readOnly,
+      rounded: this.rounded,
     });
 
     return html`

--- a/packages/web-components/src/text-area/index.ts
+++ b/packages/web-components/src/text-area/index.ts
@@ -73,6 +73,7 @@ export { BaseTextInputSlots as Slots };
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
  * @prop {"sm" | "md"} [size="md"] - The size of the input.
  * @prop {boolean} [hide-label=false] - Whether to hide the label or not.
+ * @prop {boolean} [rounded=false] - Whether the input is rounded or not.
  * @prop {number} [rows=2] -
  * The number of rows to display for the text input.
  * Defaults to 2.

--- a/packages/web-components/src/text-field/index.ts
+++ b/packages/web-components/src/text-field/index.ts
@@ -72,6 +72,7 @@ export { BaseTextInputSlots as Slots };
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
  * @prop {"sm" | "md"} [size="md"] - The size of the input.
  * @prop {boolean} [hide-label=false] - Whether to hide the label or not.
+ * @prop {boolean} [rounded=false] - Whether the input is rounded or not.
  * @prop {string} [type="text"] -
  * The `<input>` type to use, defaults to "text". The type greatly changes how
  * the text field behaves.


### PR DESCRIPTION
closes: #330 

<img width="898" alt="image" src="https://github.com/user-attachments/assets/d1598640-3cb3-4b56-aa6f-3c2ca0f4b2ab" />
